### PR TITLE
Episodes

### DIFF
--- a/webtoon-dl.py
+++ b/webtoon-dl.py
@@ -5,7 +5,8 @@
 
 import sys
 import argparse
-import os
+from os import makedirs
+from os.path import join, realpath, dirname, isfile, isdir, exists
 from bs4 import BeautifulSoup, FeatureNotFound
 from urllib import request
 import shutil
@@ -61,7 +62,7 @@ args = parser.parse_args()
 # force verbosity for now
 args.verbose = True
 
-jar = MozillaCookieJar("cookies.txt")
+jar = MozillaCookieJar(join(realpath(dirname(sys.argv[0])), "cookies.txt"))
 jar.load()
 
 def get_soup(url):
@@ -92,9 +93,9 @@ def download_images(urls, outdir):
     referer_header = { "Referer": img_referer }
 
     for c, url in enumerate(urls):
-        target = os.path.join(outdir, "{03}.jpg".format(c))
-        if os.path.isfile(target):
-            log("Image {} at {} is already dowloaded".format(c, url))
+        target = join(outdir, "{:03}.jpg".format(c))
+        if isfile(target):
+            log("Image {}  is already dowloaded".format(c, url))
             continue
 
         log("Downloading image {} at {}".format(c, url))
@@ -107,16 +108,16 @@ def download_episode(url, outdir):
     download_images(img_urls, outdir)
 
 if __name__ == "__main__":
-    if os.path.exists(args.dir):
-        if not os.path.isdir(args.dir):
+    if exists(args.dir):
+        if not isdir(args.dir):
             error("not a directory: {}".format(args.dir), 1)
     else:
-        os.makedirs(args.dir, exist_ok=True)
+        makedirs(args.dir, exist_ok=True)
 
     if args.episodes:
         for no,url in enumerate(get_episodes_urls(get_soup(args.url))):
-            outdir = os.path.join(args.dir, "{:03}".format(no))
-            os.makedirs(outdir, exist_ok=True)
+            outdir = join(args.dir, "{:03}".format(no))
+            makedirs(outdir, exist_ok=True)
             download_episode(url, outdir)
     else:
         download_episode(args.url, args.dir)

--- a/webtoon-dl.py
+++ b/webtoon-dl.py
@@ -90,27 +90,33 @@ def get_episodes_urls(soup):
 def download_images(urls, outdir):
     """Download each image in urls to existing directory outdir."""
     referer_header = { "Referer": img_referer }
+
     for c, url in enumerate(urls):
+        target = os.path.join(outdir, "{03}.jpg".format(c))
+        if os.path.isfile(target):
+            log("Image {} at {} is already dowloaded".format(c, url))
+            continue
+
         log("Downloading image {} at {}".format(c, url))
         req = request.Request(url, headers=referer_header)
-        with request.urlopen(req) as response,\
-             open(os.path.join(outdir, ":03}.jpg".format(c)), "wb") as outfile:
+        with request.urlopen(req) as response, open(target, "wb") as outfile:
             shutil.copyfileobj(response, outfile)
 
 def download_episode(url, outdir):
     img_urls = get_image_urls(get_soup(url))
     download_images(img_urls, outdir)
-            
-if os.path.exists(args.dir):
-    if not os.path.isdir(args.dir):
-        error("not a directory: {}".format(args.dir), 1)
-else:
-    os.makedirs(args.dir, exist_ok=True)
 
-if args.episodes:
-    for no,url in enumerate(get_episodes_urls(get_soup(args.url))):
-        outdir = os.path.join(args.dir, "{:03}".format(no))
-        os.makedirs(outdir, exist_ok=True)
-        download_episode(url, outdir)
-else:
-    download_episode(args.url, args.dir)
+if __name__ == "__main__":
+    if os.path.exists(args.dir):
+        if not os.path.isdir(args.dir):
+            error("not a directory: {}".format(args.dir), 1)
+    else:
+        os.makedirs(args.dir, exist_ok=True)
+
+    if args.episodes:
+        for no,url in enumerate(get_episodes_urls(get_soup(args.url))):
+            outdir = os.path.join(args.dir, "{:03}".format(no))
+            os.makedirs(outdir, exist_ok=True)
+            download_episode(url, outdir)
+    else:
+        download_episode(args.url, args.dir)

--- a/webtoon-dl.py
+++ b/webtoon-dl.py
@@ -5,7 +5,7 @@
 
 import sys
 import argparse
-from os import makedirs
+from os import makedirs, listdir
 from os.path import join, realpath, dirname, isfile, isdir, exists
 from bs4 import BeautifulSoup, FeatureNotFound
 from urllib import request
@@ -54,7 +54,13 @@ def mkdir(*args, **kwargs):
     if not dry:
         return makedirs(*args, **kwargs)
     log("faking make directory" + str(args))
-        
+    
+"""guess already downloaded episodes in a directory"""
+def guess_start(d):
+    return max([int(x) for x in listdir(d) if x.isdecimal()]) - 1
+
+# checks if there are episode folders into the targeted folder
+    
 parser = ArgumentParserUsage(description="Download all images from a LINE Webtoon comic episode.")
 parser.add_argument("-v", "--verbose", action="store_true", help="be verbose")
 parser.add_argument("-p", "--dry-run", action="store_true",
@@ -132,6 +138,9 @@ if __name__ == "__main__":
         mkdir(args.dir, exist_ok=True)
 
     if args.episodes:
+        if args.guess_start:
+            args.start = guess_start(args.dir)
+
         for no,url in enumerate(get_episodes_urls(get_soup(args.url))
                                 [args.start:], start = args.start):
             outdir = join(args.dir, "{:03}".format(no))

--- a/webtoon-dl.py
+++ b/webtoon-dl.py
@@ -80,6 +80,9 @@ group.add_argument("-s", "--start", default=0, type=int, metavar="ST",
 group.add_argument("-g", "--guess-start", action="store_true",
                     help="guess the already downloadded episodes, "  
                     "to be used with -e.")
+parser.add_argument("-n", "--no-check", action="store_false", dest="check",
+                    help="check for a comic stamp in the dest folder"  
+                    "used to avoid errors, to be used with -e.")
 parser.add_argument("url", metavar="URL", help="Webtoon comic URL")
 
 jar = MozillaCookieJar(join(realpath(dirname(FILENAME)), "cookies.txt"))
@@ -147,16 +150,17 @@ if __name__ == "__main__":
 
     if args.episodes:
         # checking
-        stamp = join(args.dir, ".webtoon-dl")
-        if isfile(stamp):
-            log("checking stamp in dest dir")
-            with open(stamp, 'r') as f:
-                if f.read() != get_name(args.url):
-                    error("non-matching stamps", 2)
-        else:
-            log("writing stamp in dest dir")
-            with open(stamp, 'w') as f:
-                f.write(get_name(args.url))
+        if args.check:
+            stamp = join(args.dir, ".webtoon-dl")
+            if isfile(stamp):
+                log("checking stamp in dest dir")
+                with open(stamp, 'r') as f:
+                    if f.read() != get_name(args.url):
+                        error("non-matching stamps", 2)
+            else:
+                log("writing stamp in dest dir")
+                with open(stamp, 'w') as f:
+                    f.write(get_name(args.url))
 
         if args.guess_start:
             args.start = guess_start(args.dir)

--- a/webtoon-dl.py
+++ b/webtoon-dl.py
@@ -53,15 +53,21 @@ def error(message, exit_code=None):
 
 parser = ArgumentParserUsage(description="Download all images from a LINE Webtoon comic episode.")
 parser.add_argument("-v", "--verbose", action="store_true", help="be verbose")
+parser.add_argument("--dry-run", action="store_true", help="do not download "
+                    "files, only print urls")
 parser.add_argument("-d", "--dir", default=".",
                     help="directory to store downloaded images in (default: .)")
 parser.add_argument("-e", "--episodes", action="store_true",
                     help="download full serie, each episode in a directory "
                     "regardless the provided episode")
-parser.add_argument("-s", "--start", default=0, type=int, metavar="ST",
+group = parser.add_mutually_exclusive_group()
+group.add_argument("-s", "--start", default=0, type=int, metavar="ST",
                     help="starting episode, to be used with -e. "
                     "Warning : episode number in webtoons and episode number"
                     "in the title may not match the value")
+group.add_argument("-g", "--guess-start", action="store_true",
+                    help="guess the already downloadded episodes, "  
+                    "to be used with -e.")
 parser.add_argument("url", metavar="URL", help="Webtoon comic URL")
 
 jar = MozillaCookieJar(join(realpath(dirname(FILENAME)), "cookies.txt"))
@@ -120,6 +126,7 @@ if __name__ == "__main__":
         makedirs(args.dir, exist_ok=True)
 
     if args.episodes:
+        print(args.guess_start)
         for no,url in enumerate(get_episodes_urls(get_soup(args.url))
                                 [args.start:], start = args.start):
             outdir = join(args.dir, "{:03}".format(no))


### PR DESCRIPTION
add some support to download all the episodes of a webcomic, including

 * downloading every episode after episode number n (not precise: sometimes Webtoons or authors messes with episode numbering)
 * auto-guess this number n according to folders inside the target directory
 * do not re-download an already downloaded picture (rough approximate)
 * check if you are downloading a webcomic in a directory already occupied by another webcomic by putting the name of the comic into a `.webtoon-dl` file.
 * added a dry-run option, convenient for testing purposes