### PR TITLE
makepage written in Soup

### DIFF
--- a/makepage.py
+++ b/makepage.py
@@ -1,0 +1,43 @@
+"""Create a webpage (same as make-page but in python)"""
+
+from sys import argv
+from argparse import ArgumentParser
+from os.path import dirname, basename, splitext, join
+from os import listdir
+
+from bs4 import BeautifulSoup
+
+DIRNAME = dirname(argv[0])
+EXT = ".jpg"
+
+parser = ArgumentParser(
+    description="Create a webpage to display a comic in browser")
+
+parser.add_argument("-t", "--title", help="page title")
+parser.add_argument("-s", "--style", help="the style sheet",
+                    default=join(DIRNAME, "main.css"))
+parser.add_argument("-o", "--outfile", help="outfile name", default="./")
+parser.add_argument("-v", "--verbose", help="be verbose")
+
+
+def guess_files(d):
+    """guess files that are probably comic panels"""
+    return [x for x in listdir(d)
+            if splitext(basename(x))[0].isdecimal()]
+
+
+def make_episode(flist, title, css):
+    """return the soup of a webpage containing an episode
+    title: the list of the episodes
+    flist: the list of the images"""
+    with open(join(DIRNAME, "template.html")) as _f:
+        soup = BeautifulSoup(_f)
+    soup.head.title.string = title
+    soup.head.link["href"] = css
+    soup.body.extend([soup.new_tag("img", src=f) for f in flist])
+    return soup
+
+
+if __name__ == "__main__":
+    args = parser.parse_args()
+    print(make_episode(guess_files(args.outdir), args.title, args.style))

--- a/makepage.py
+++ b/makepage.py
@@ -1,3 +1,5 @@
+#! /usr/bin/env python3
+
 """Create a webpage (same as make-page but in python)"""
 
 from sys import argv
@@ -13,16 +15,18 @@ EXT = ".jpg"
 parser = ArgumentParser(
     description="Create a webpage to display a comic in browser")
 
-parser.add_argument("-t", "--title", help="page title")
+parser.add_argument("-t", "--title", help="page title",
+                    default="title")
 parser.add_argument("-s", "--style", help="the style sheet",
                     default=join(DIRNAME, "main.css"))
-parser.add_argument("-o", "--outfile", help="outfile name", default="./")
+parser.add_argument("-o", "--outfile", help="outfile name",
+                    default="index.html")
 parser.add_argument("-v", "--verbose", help="be verbose")
-
+parser.add_argument("dir", help="the directory of the episode")
 
 def guess_files(d):
     """guess files that are probably comic panels"""
-    return [x for x in listdir(d)
+    return [x for x in sorted(listdir(d))
             if splitext(basename(x))[0].isdecimal()]
 
 
@@ -30,8 +34,8 @@ def make_episode(flist, title, css):
     """return the soup of a webpage containing an episode
     title: the list of the episodes
     flist: the list of the images"""
-    with open(join(DIRNAME, "template.html")) as _f:
-        soup = BeautifulSoup(_f)
+    with open(join(DIRNAME, "template.html")) as f:
+        soup = BeautifulSoup(f, "html.parser")
     soup.head.title.string = title
     soup.head.link["href"] = css
     soup.body.extend([soup.new_tag("img", src=f) for f in flist])
@@ -40,4 +44,6 @@ def make_episode(flist, title, css):
 
 if __name__ == "__main__":
     args = parser.parse_args()
-    print(make_episode(guess_files(args.outdir), args.title, args.style))
+    with open(args.outfile, "w") as f:
+        soup = make_episode(guess_files(args.dir), args.title, args.style)
+        f.write(soup.prettify())

--- a/template.html
+++ b/template.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link rel="stylesheet" type="text/css" href="#CSS#">
+    <title>#TITLE#</title>
+  </head>
+  <body>
+  </body>
+</html>


### PR DESCRIPTION
replacing make-page by makepage.py would allow to merge the downloader and the ”pager” in one cmdline tool, which would allow easier information sharing (e.g. when building HTML pages for the whole comic), and also to show to the rest of the world that BeautifulSoup is very convenient, not only to scrape webpages, but also to create ones.
It would also remove the dependency  from [bashplate](https://github.com/raehik/bashplate), so the installation would become easier.